### PR TITLE
feat(frontend): add Axios service layer and itinerary API integration

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,16 @@
+import axios from "axios";
+
+export const http = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE ?? "http://localhost:8080",
+  timeout: 15000,
+  headers: { "Content-Type": "application/json" },
+});
+
+// Optional: normalize errors
+http.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    const msg = err?.response?.data?.message || err?.message || "Network error. Please try again.";
+    return Promise.reject(new Error(msg));
+  },
+);

--- a/frontend/src/api/itinerary.ts
+++ b/frontend/src/api/itinerary.ts
@@ -1,17 +1,36 @@
-import type { TripInput, Itinerary } from '../types/itinerary'
-import { generateMockItinerary } from '../mocks/mockData'
+import { http } from "./http";
+import type { TripInput, Itinerary } from "../types/itinerary";
+import { generateMockItinerary } from "../mocks/mockData";
 
-const API_BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8080'
-const USE_MOCK = (import.meta.env.VITE_USE_MOCK ?? 'true') === 'true'
+const USE_MOCK = (import.meta.env.VITE_USE_MOCK ?? "true") === "true";
 
 export async function generateItinerary(input: TripInput): Promise<Itinerary> {
-  if (USE_MOCK) return generateMockItinerary(input)
+  if (USE_MOCK) return generateMockItinerary(input);
+  const { data } = await http.post<Itinerary>("/api/itineraries/generate", input);
+  return data;
+}
 
-  const res = await fetch(`${API_BASE}/api/itineraries/generate`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
-  })
-  if (!res.ok) throw new Error(`Failed to generate itinerary (${res.status})`)
-  return res.json()
+export async function getItineraryById(id: string): Promise<Itinerary> {
+  if (USE_MOCK) {
+    return generateMockItinerary({
+      destination: "Mock City",
+      startDate: "2025-01-01",
+      endDate: "2025-01-03",
+      budget: 1000,
+      interests: ["food", "culture"],
+      origin: "Mock Origin",
+    });
+  }
+
+  const { data } = await http.get<Itinerary>(`/api/itineraries/${id}`);
+  return data;
+}
+
+export async function pingBackend(): Promise<boolean> {
+  try {
+    await http.get("/api/health");
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Env: set VITE_API_BASE and VITE_USE_MOCK in .env.local

How to test: run npm run dev, submit trip form, see mock itinerary; flip VITE_USE_MOCK=false when backend is ready.